### PR TITLE
Reduce production bundle size

### DIFF
--- a/src/components/Explore/Explore.js
+++ b/src/components/Explore/Explore.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import { Button } from 'react-bootstrap';
+import  Button  from 'react-bootstrap/lib/Button';
 
 const GITHUB_REPO = 'https://github.com/xkawi/react-universal-saga';
 

--- a/src/components/Explore/Explore.js
+++ b/src/components/Explore/Explore.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import  Button  from 'react-bootstrap/lib/Button';
+import Button from 'react-bootstrap/lib/Button';
 
 const GITHUB_REPO = 'https://github.com/xkawi/react-universal-saga';
 

--- a/src/containers/Root/Root.dev.js
+++ b/src/containers/Root/Root.dev.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import has from 'lodash/has';
 import React, { Component, PropTypes } from 'react';
 import { Provider } from 'react-redux';
 import { Router, RouterContext } from 'react-router';
@@ -15,7 +15,7 @@ export default class Root extends Component {
     const { store, type } = this.props;
     if (type !== 'server') {
       const state = store.getState();
-      if (_.has(state, 'router.pathname')) {
+      if (has(state, 'router.pathname')) {
         GoogleAnalytics.pageview(state.router.pathname);
       }
     }

--- a/src/containers/Root/Root.prod.js
+++ b/src/containers/Root/Root.prod.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import has from 'lodash/has';
 import React, { Component, PropTypes } from 'react';
 import { Provider } from 'react-redux';
 import { Router, RouterContext } from 'react-router';
@@ -14,7 +14,7 @@ export default class Root extends Component {
     const { store, type } = this.props;
     if (type !== 'server') {
       const state = store.getState();
-      if (_.has(state, 'router.pathname')) {
+      if (has(state, 'router.pathname')) {
         GoogleAnalytics.pageview(state.router.pathname);
       }
     }

--- a/src/containers/UserPage/UserPage.js
+++ b/src/containers/UserPage/UserPage.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import zip from 'lodash/zip';
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { loadUserPage, loadMoreStarred } from '../../actions';
@@ -44,7 +44,7 @@ class UserPage extends Component {
         <hr />
         <List
           renderItem={this.renderRepo}
-          items={_.zip(starredRepos, starredRepoOwners)}
+          items={zip(starredRepos, starredRepoOwners)}
           onLoadMoreClick={this.handleLoadMoreClick}
           loadingLabel={`Loading ${login}’s starred...`}
           {...starredPagination}

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -3,4 +3,3 @@ export App from './App/App';
 export UserPage from './UserPage/UserPage';
 export RepoPage from './RepoPage/RepoPage';
 export NotFound from './NotFound/NotFound';
-export DevTools from './DevTools/DevTools';

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,12 +1,12 @@
 import * as ActionTypes from '../actions';
-import _ from 'lodash';
+import merge from 'lodash/merge';
 import paginate from './paginate';
 import { combineReducers } from 'redux';
 
 // Updates an entity cache in response to any action with response.entities.
 function entities(state = { users: {}, repos: {} }, action) {
   if (action.response && action.response.entities) {
-    return _.merge({}, state, action.response.entities);
+    return merge({}, state, action.response.entities);
   }
 
   return state;

--- a/src/reducers/paginate.js
+++ b/src/reducers/paginate.js
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import merge from 'lodash/merge';
+import union from 'lodash/union';
 
 // Creates a reducer managing pagination, given the action types to handle,
 // and a function telling how to extract the key from an action.
@@ -23,18 +24,18 @@ export default function paginate({ types, mapActionToKey }) {
   }, action) {
     switch (action.type) {
       case requestType:
-        return _.merge({}, state, {
+        return merge({}, state, {
           isFetching: true
         });
       case successType:
-        return _.merge({}, state, {
+        return merge({}, state, {
           isFetching: false,
-          ids: _.union(state.ids, action.response.result),
+          ids: union(state.ids, action.response.result),
           nextPageUrl: action.response.nextPageUrl,
           pageCount: state.pageCount + 1
         });
       case failureType:
-        return _.merge({}, state, {
+        return merge({}, state, {
           isFetching: false
         });
       default:
@@ -51,7 +52,7 @@ export default function paginate({ types, mapActionToKey }) {
         if (typeof key !== 'string') {
           throw new Error('Expected key to be a string.');
         }
-        return _.merge({}, state, {
+        return merge({}, state, {
           [key]: updatePagination(state[key], action)
         });
       }

--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -1,7 +1,7 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import createLogger from 'redux-logger';
 import createSagaMiddleware, { END } from 'redux-saga';
-import  DevTools  from 'containers/DevTools/DevTools';
+import DevTools from 'containers/DevTools/DevTools';
 import rootReducer from '../reducers';
 
 export default function configureStore(history, initialState) {

--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -1,7 +1,7 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import createLogger from 'redux-logger';
 import createSagaMiddleware, { END } from 'redux-saga';
-import { DevTools } from 'containers';
+import  DevTools  from 'containers/DevTools/DevTools';
 import rootReducer from '../reducers';
 
 export default function configureStore(history, initialState) {


### PR DESCRIPTION
Hi
Based on my finding here  #6, I managed to drop the production bundle size from about 782 to 432 by doing the following:
1. Optimizing lodash imports
2. Fixing the issue that led to DevTools container being included in the production bundle.
3. Importing only Button from react-bootstrap instead of the whole module.
