### PR TITLE
fix redux-saga usage for 0.14.8

### DIFF
--- a/src/sagas/waitAll.js
+++ b/src/sagas/waitAll.js
@@ -2,5 +2,5 @@ import { fork, join } from 'redux-saga/effects';
 
 export default (sagas) => function* genTasks() {
   const tasks = yield sagas.map(([saga, ...params]) => fork(saga, ...params));
-  yield tasks.map(join);
+  yield join(...tasks);
 };


### PR DESCRIPTION
It was failing here with this error.
```
Error: join(task): argument 0 is not a valid Task object
(HINT: if you are getting this errors in tests, consider using createMockTask from redux-saga/utils)
```