### PR TITLE
fix redux-saga usage for 0.15.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "react-router": "^2.5.2",
     "redux": "^3.5.2",
     "redux-logger": "^3.0.1",
-    "redux-saga": "^0.14.5",
+    "redux-saga": "^0.15.3",
     "scroll-behavior": "^0.8.2",
     "serialize-javascript": "^1.1.2",
     "serve-favicon": "^2.3.0",

--- a/src/sagas/waitAll.js
+++ b/src/sagas/waitAll.js
@@ -2,5 +2,7 @@ import { fork, join } from 'redux-saga/effects';
 
 export default (sagas) => function* genTasks() {
   const tasks = yield sagas.map(([saga, ...params]) => fork(saga, ...params));
-  yield tasks.map(join);
+  if (tasks.length) {
+    yield join(...tasks);
+  }
 };


### PR DESCRIPTION
It was failing here with this error.
```
Error: join(task): argument 0 is not a valid Task object
(HINT: if you are getting this errors in tests, consider using createMockTask from redux-saga/utils)
```

I updated redux-saga to latest as well!

I closed last PR by mistake. https://github.com/xkawi/react-universal-saga/pull/14